### PR TITLE
Add automated deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy Jekyll SPA on main
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: |
+          bundle config set without 'development test'
+          bundle install --jobs 4 --retry 3
+
+      - name: Build Jekyll
+        run: bundle exec jekyll build --trace
+
+      - name: Create release package
+        run: |
+          RELEASE="release_$(date +%Y%m%d_%H%M%S)"
+          echo "$RELEASE" > release_name.txt
+          tar -C "_site" -czf "${RELEASE}.tar.gz" .
+
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Add host to known_hosts
+        run: ssh-keyscan -p "${{ secrets.SSH_PORT }}" -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload release to server
+        run: |
+          RELEASE=$(cat release_name.txt)
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -p "${{ secrets.SSH_PORT }}" "mkdir -p ${{ secrets.SERVER_PATH }}/releases/${RELEASE}"
+          scp -P "${{ secrets.SSH_PORT }}" "${RELEASE}.tar.gz" ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/tmp/
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -p "${{ secrets.SSH_PORT }}" \
+            "tar -xzf /tmp/${RELEASE}.tar.gz -C ${{ secrets.SERVER_PATH }}/releases/${RELEASE} && rm /tmp/${RELEASE}.tar.gz"
+
+      - name: Switch symlink & reload Nginx
+        run: |
+          RELEASE=$(cat release_name.txt)
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -p "${{ secrets.SSH_PORT }}" "bash ${{ secrets.SERVER_PATH }}/post_deploy.sh ${RELEASE}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,30 @@
+source "https://rubygems.org"
+
+# Jekyll version compatible with GitHub Pages and the deployment workflow
+gem "jekyll", "~> 4.3"
+
+# Jekyll plugins
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.17"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
+end
+
+# Development dependencies
+group :development, :test do
+  gem "webrick", "~> 1.8"  # Required for Ruby 3.0+
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+APP_DIR="/var/www/nearweek"
+REL_DIR="$APP_DIR/releases"
+RELEASE_NAME="${1:?release name required}"
+NEW_DIR="$REL_DIR/$RELEASE_NAME"
+CURRENT="$APP_DIR/current"
+
+# (if you need shared files — .env, etc.)
+mkdir -p "$APP_DIR/shared"
+
+# Switch current -> new release (atomically)
+ln -sfn "$NEW_DIR" "$CURRENT"
+
+# Permissions
+chown -h deploy:deploy "$CURRENT"
+chown -R deploy:deploy "$NEW_DIR"
+
+# Check Nginx configuration
+sudo -n /usr/sbin/nginx -t
+
+# Restarting Nginx
+sudo -n /usr/bin/systemctl reload nginx
+
+# Rotation: keep 5 releases
+cd "$REL_DIR"
+ls -1dt */ | tail -n +6 | xargs -r rm -rf


### PR DESCRIPTION
Add automated deployment workflow

This PR adds GitHub Actions CI/CD automation for the Jekyll site:

- GitHub Actions workflow (.github/workflows/deploy.yml): Builds Jekyll site on push to main, creates timestamped
releases, and deploys to remote server via SSH
- Post-deployment script (scripts/post_deploy.sh): Manages symlink switching and Nginx reload on the server
- Gemfile: Defines Jekyll dependencies for build environment

The deployment workflow requires SSH secrets configuration: SSH_KEY, SSH_PORT, SSH_HOST, SSH_USER, SERVER_PATH
